### PR TITLE
Fixed alignment issues mentioned in Issue #6

### DIFF
--- a/frontend/src/components/practice/contests/ContestCard.jsx
+++ b/frontend/src/components/practice/contests/ContestCard.jsx
@@ -56,7 +56,7 @@ const ContestCard = (props) => {
   }, []);
   return (
     <div className="c-card">
-      <div className="c-name">{props.contest.name}</div>
+      <div className="c-name w-100">{props.contest.name}</div>
       <Stack direction="horizontal" className="c-problems-container" gap={1}>
         {problems.map((problem) => {
           return (
@@ -71,7 +71,7 @@ const ContestCard = (props) => {
           );
         })}
       </Stack>
-      <div className="c-btn-container">
+      <div className="d-flex justify-content-end c-btn-container w-100">
         <Button
           className="c-btn"
           variant="outline-success"


### PR DESCRIPTION
fixes #6 
- aligned buttons to the right
- contest names are left aligned
- ample space is present between the name and the button group

![Screenshot from 2023-10-01 18-14-45](https://github.com/Traveller08/wecode/assets/31540054/f2579130-4d50-4127-8e3c-dc2efcd1f9ff)
